### PR TITLE
feat(ui): improve accessibility and screen reader support across UI components

### DIFF
--- a/app/src/main/java/com/mrsep/musicrecognizer/presentation/AppNavigationBar.kt
+++ b/app/src/main/java/com/mrsep/musicrecognizer/presentation/AppNavigationBar.kt
@@ -60,7 +60,7 @@ fun AppNavigationBar(
                                 if (selected) destinationEntry.selectedIconResId
                                 else destinationEntry.unselectedIconResId
                             ),
-                            contentDescription = stringResource(destinationEntry.titleResId)
+                            contentDescription = null
                         )
                     }
                 },
@@ -137,7 +137,7 @@ fun LibraryNavigationIcon(
                 if (selected) TopLevelDestination.Library.selectedIconResId
                 else TopLevelDestination.Library.unselectedIconResId
             ),
-            contentDescription = stringResource(TopLevelDestination.Library.titleResId)
+            contentDescription = null
         )
     }
 }

--- a/app/src/main/java/com/mrsep/musicrecognizer/presentation/AppNavigationRail.kt
+++ b/app/src/main/java/com/mrsep/musicrecognizer/presentation/AppNavigationRail.kt
@@ -40,7 +40,7 @@ fun AppNavigationRail(
                                 if (selected) destinationEntry.selectedIconResId
                                 else destinationEntry.unselectedIconResId
                             ),
-                            contentDescription = stringResource(destinationEntry.titleResId)
+                            contentDescription = null
                         )
                     }
                 },

--- a/core/strings/src/main/res/values-ar/strings.xml
+++ b/core/strings/src/main/res/values-ar/strings.xml
@@ -333,5 +333,4 @@
     <string name="about_pref_title_donation">التبرع</string>
     <string name="about_pref_subtitle_donation">ادعم المشروع</string>
     <string name="about_pref_donation_message">هذا التطبيق مجاني تمامًا، ولا يحتوي على أي إعلانات أو أي شكل من أشكال الربح التجاري. لدعم التطوير المستمر أو لمجرد التعبير عن الشكر، يُرجى التبرع. شكرًا لدعمكم!</string>
-    <string name="reorder">إعادة ترتيب</string>
 </resources>

--- a/core/strings/src/main/res/values-ar/strings.xml
+++ b/core/strings/src/main/res/values-ar/strings.xml
@@ -333,4 +333,5 @@
     <string name="about_pref_title_donation">التبرع</string>
     <string name="about_pref_subtitle_donation">ادعم المشروع</string>
     <string name="about_pref_donation_message">هذا التطبيق مجاني تمامًا، ولا يحتوي على أي إعلانات أو أي شكل من أشكال الربح التجاري. لدعم التطوير المستمر أو لمجرد التعبير عن الشكر، يُرجى التبرع. شكرًا لدعمكم!</string>
+    <string name="reorder">إعادة ترتيب</string>
 </resources>

--- a/core/strings/src/main/res/values/strings.xml
+++ b/core/strings/src/main/res/values/strings.xml
@@ -390,4 +390,5 @@
     <string name="audd_sign_up_url" translatable="false">https://dashboard.audd.io/</string>
     <string name="audd_terms_url" translatable="false">https://audd.io/terms/</string>
     <string name="acrcloud_project_guide_url" translatable="false">https://docs.acrcloud.com/tutorials/recognize-music/</string>
+    <string name="reorder">Reorder</string>
 </resources>

--- a/core/ui/src/main/java/com/mrsep/musicrecognizer/core/ui/components/preferences/PreferenceClickableItem.kt
+++ b/core/ui/src/main/java/com/mrsep/musicrecognizer/core/ui/components/preferences/PreferenceClickableItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
@@ -22,7 +23,7 @@ fun PreferenceClickableItem(
         modifier = modifier
             .fillMaxWidth()
             .heightIn(min = 80.dp)
-            .clickable { onItemClick() }
+            .clickable(enabled = enabled, role = Role.Button) { onItemClick() }
             .padding(16.dp)
             .alpha(if (enabled) 1f else 0.7f)
     ) {

--- a/core/ui/src/main/java/com/mrsep/musicrecognizer/core/ui/components/preferences/PreferenceGroup.kt
+++ b/core/ui/src/main/java/com/mrsep/musicrecognizer/core/ui/components/preferences/PreferenceGroup.kt
@@ -8,6 +8,8 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.semantics.heading
+import androidx.compose.ui.semantics.semantics
 
 @Composable
 fun PreferenceGroup(
@@ -20,7 +22,9 @@ fun PreferenceGroup(
             text = title,
             style = MaterialTheme.typography.titleSmall,
             color = MaterialTheme.colorScheme.tertiary,
-            modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp)
+            modifier = Modifier
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+                .semantics { heading() }
         )
         Column {
             content()

--- a/core/ui/src/main/java/com/mrsep/musicrecognizer/core/ui/components/preferences/PreferenceSwitchItem.kt
+++ b/core/ui/src/main/java/com/mrsep/musicrecognizer/core/ui/components/preferences/PreferenceSwitchItem.kt
@@ -1,6 +1,7 @@
 package com.mrsep.musicrecognizer.core.ui.components.preferences
 
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.ui.semantics.Role
 import androidx.compose.foundation.layout.*
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
@@ -24,9 +25,11 @@ fun PreferenceSwitchItem(
         modifier = modifier
             .fillMaxWidth()
             .heightIn(min = 80.dp)
-            .clickable(
-                onClick = onClick,
-                enabled = enabled
+            .toggleable(
+                value = checked,
+                enabled = enabled,
+                role = Role.Switch,
+                onValueChange = { onClick() }
             )
             .padding(16.dp)
     ) {

--- a/feature/backup/src/main/java/com/mrsep/musicrecognizer/feature/backup/presentation/BackupDialog.kt
+++ b/feature/backup/src/main/java/com/mrsep/musicrecognizer/feature/backup/presentation/BackupDialog.kt
@@ -1,7 +1,8 @@
 package com.mrsep.musicrecognizer.feature.backup.presentation
 
 import android.content.Context
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
+import androidx.compose.ui.semantics.Role
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -199,13 +200,16 @@ internal fun BackupEntryCheckBox(
         modifier = Modifier
             .fillMaxWidth()
             .clip(MaterialTheme.shapes.medium)
-            .clickable(onClick = onClick),
+            .toggleable(
+                value = checked,
+                role = Role.Checkbox,
+                onValueChange = { onClick() }
+            ),
         verticalAlignment = Alignment.CenterVertically,
-
-        ) {
+    ) {
         Checkbox(
             checked = checked,
-            onCheckedChange = { onClick() }
+            onCheckedChange = null
         )
         Column(
             modifier = Modifier.weight(1f)

--- a/feature/backup/src/main/java/com/mrsep/musicrecognizer/feature/backup/presentation/CsvExportFullScreenDialog.kt
+++ b/feature/backup/src/main/java/com/mrsep/musicrecognizer/feature/backup/presentation/CsvExportFullScreenDialog.kt
@@ -286,7 +286,7 @@ private fun CsvExportReadyContent(
                         Row(verticalAlignment = Alignment.CenterVertically) {
                             Checkbox(
                                 checked = selectable.selected,
-                                onCheckedChange = { onItemSelect() }
+                                onCheckedChange = null
                             )
                             if (selectable.field is TrackLinkField || selectable.field == TrackField.LINK_ARTWORK) {
                                 Icon(
@@ -312,7 +312,7 @@ private fun CsvExportReadyContent(
                             ) {
                                 Icon(
                                     painter = painterResource(UiR.drawable.outline_drag_handle_24),
-                                    contentDescription = "Reorder"
+                                    contentDescription = stringResource(StringsR.string.reorder)
                                 )
                             }
                         }

--- a/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/library/LibraryScreenTopBar.kt
+++ b/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/library/LibraryScreenTopBar.kt
@@ -10,6 +10,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.intl.Locale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.toUpperCase
@@ -161,6 +165,10 @@ private fun LibraryDropdownMenu(
         ) {
             DropdownMenuItem(
                 text = { Text(text = stringResource(StringsR.string.pref_title_use_grid_layout)) },
+                modifier = Modifier.semantics {
+                    role = Role.Checkbox
+                    selected = useGridLayout
+                },
                 onClick = { onChangeUseGridLayout(!useGridLayout) },
                 trailingIcon = {
                     Icon(
@@ -174,6 +182,10 @@ private fun LibraryDropdownMenu(
             )
             DropdownMenuItem(
                 text = { Text(text = stringResource(StringsR.string.pref_title_show_recognition_date)) },
+                modifier = Modifier.semantics {
+                    role = Role.Checkbox
+                    selected = showRecognitionDate
+                },
                 onClick = { onChangeShowRecognitionDate(!showRecognitionDate) },
                 trailingIcon = {
                     Icon(

--- a/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/library/TrackLazyColumn.kt
+++ b/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/library/TrackLazyColumn.kt
@@ -37,6 +37,10 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import coil3.compose.AsyncImage
 import com.mrsep.musicrecognizer.core.ui.components.MultiSelectionState
 import com.mrsep.musicrecognizer.core.ui.util.forwardingPainter
@@ -109,6 +113,10 @@ private fun TrackLazyColumnItem(
         modifier = modifier
             .fillMaxWidth()
             .drawBehind { drawRect(color = containerColor) }
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                this.selected = selected
+            }
             .combinedClickable(
                 interactionSource = null,
                 indication = LocalIndication.current,

--- a/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/library/TrackLazyGrid.kt
+++ b/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/library/TrackLazyGrid.kt
@@ -21,6 +21,10 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import coil3.compose.AsyncImage
 import com.mrsep.musicrecognizer.core.ui.components.MultiSelectionState
 import com.mrsep.musicrecognizer.core.ui.util.forwardingPainter
@@ -88,6 +92,10 @@ private fun TrackLazyGridItem(
             .fillMaxSize()
             .clip(shape)
             .drawBehind { drawRect(color = containerColor) }
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+                this.selected = selected
+            }
             .combinedClickable(
                 interactionSource = null,
                 indication = LocalIndication.current,

--- a/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/search/SearchScopeDropdownMenu.kt
+++ b/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/search/SearchScopeDropdownMenu.kt
@@ -20,6 +20,10 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.selected
+import androidx.compose.ui.semantics.semantics
 import com.mrsep.musicrecognizer.core.domain.track.model.TrackDataField
 import kotlinx.collections.immutable.ImmutableSet
 import com.mrsep.musicrecognizer.core.strings.R as StringsR
@@ -57,6 +61,10 @@ internal fun SearchScopeDropdownMenu(
                 val selected = searchScope.contains(field)
                 DropdownMenuItem(
                     text = { Text(text = field.getTitle()) },
+                    modifier = Modifier.semantics {
+                        role = Role.Checkbox
+                        selected = selected
+                    },
                     onClick = {
                         if (searchScope.size != 1 || !selected) {
                             val newSearchScope =

--- a/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/search/TrackSearchItem.kt
+++ b/feature/library/src/main/java/com/mrsep/musicrecognizer/feature/library/presentation/search/TrackSearchItem.kt
@@ -24,6 +24,9 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import coil3.compose.AsyncImage
 import com.mrsep.musicrecognizer.core.domain.track.model.TrackDataField
 import com.mrsep.musicrecognizer.core.ui.util.forwardingPainter
@@ -47,6 +50,9 @@ internal fun TrackSearchItem(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .fillMaxWidth()
+            .semantics(mergeDescendants = true) {
+                role = Role.Button
+            }
             .clickable(onClick = onClick)
             .padding(contentPadding)
     ) {

--- a/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/presentation/recognitionscreen/RecognitionButtonWithTitle.kt
+++ b/feature/recognition/src/main/java/com/mrsep/musicrecognizer/feature/recognition/presentation/recognitionscreen/RecognitionButtonWithTitle.kt
@@ -14,7 +14,9 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -61,8 +63,8 @@ internal fun RecognitionButtonWithTitle(
                 ),
                 textAlign = TextAlign.Center,
                 modifier = Modifier
-                    .clearAndSetSemantics { }
                     .fillMaxWidth()
+                    .semantics { liveRegion = LiveRegionMode.Polite }
                     .padding(bottom = 40.dp)
             )
         }
@@ -166,7 +168,7 @@ private fun BasicRecognitionButton(
                     else StringsR.string.action_recognize
                 ),
                 onLongClick = onLongClick.takeIf { !activated },
-                onLongClickLabel = stringResource(StringsR.string.action_recognize).takeIf { !activated },
+                onLongClickLabel = stringResource(StringsR.string.audio_source_dialog_button_long_press_mode_title).takeIf { !activated },
                 role = Role.Button
             ),
         shape = CircleShape,

--- a/feature/track/src/main/java/com/mrsep/musicrecognizer/feature/track/presentation/lyrics/LyricsStyleBottomSheet.kt
+++ b/feature/track/src/main/java/com/mrsep/musicrecognizer/feature/track/presentation/lyrics/LyricsStyleBottomSheet.kt
@@ -1,7 +1,7 @@
 package com.mrsep.musicrecognizer.feature.track.presentation.lyrics
 
 import androidx.compose.foundation.LocalIndication
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.selection.toggleable
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.rememberScrollState
@@ -12,6 +12,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.unit.dp
 import com.mrsep.musicrecognizer.core.domain.preferences.FontSize
 import com.mrsep.musicrecognizer.core.domain.preferences.LyricsStyle
@@ -50,6 +53,8 @@ internal fun LyricsStyleBottomSheet(
                 Text(text = style.fontSize.title())
             }
             Spacer(Modifier.height(8.dp))
+            val fontSizeDesc = stringResource(StringsR.string.font_size)
+            val fontSizeState = style.fontSize.title()
             Slider(
                 value = style.fontSize.ordinal.toFloat(),
                 onValueChange = { sliderValue ->
@@ -58,7 +63,12 @@ internal fun LyricsStyleBottomSheet(
                 },
                 valueRange = 0f..3f,
                 steps = 2,
-                modifier = Modifier.padding(horizontal = 16.dp)
+                modifier = Modifier
+                    .padding(horizontal = 16.dp)
+                    .semantics {
+                        contentDescription = fontSizeDesc
+                        stateDescription = fontSizeState
+                    }
             )
             Spacer(Modifier.height(8.dp))
             Column(verticalArrangement = Arrangement.spacedBy(2.dp)) {
@@ -102,12 +112,13 @@ private fun BottomBarSwitch(
         verticalAlignment = Alignment.CenterVertically,
         modifier = modifier
             .fillMaxWidth()
-            .clickable(
+            .toggleable(
+                value = checked,
                 interactionSource = null,
                 indication = LocalIndication.current,
                 enabled = enabled,
                 role = Role.Switch,
-                onClick = onClick
+                onValueChange = { onClick() }
             )
             .padding(horizontal = 16.dp)
     ) {
@@ -117,7 +128,7 @@ private fun BottomBarSwitch(
         )
         Switch(
             checked = checked,
-            onCheckedChange = { onClick() },
+            onCheckedChange = null,
             enabled = enabled
         )
     }

--- a/feature/track/src/main/java/com/mrsep/musicrecognizer/feature/track/presentation/track/AlbumArtwork.kt
+++ b/feature/track/src/main/java/com/mrsep/musicrecognizer/feature/track/presentation/track/AlbumArtwork.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.Shape
@@ -104,6 +105,8 @@ internal fun AlbumArtwork(
                 if (onLoadedArtworkClick != null) {
                     Modifier.clickable(
                         enabled = painterState is AsyncImagePainter.State.Success,
+                        role = Role.Button,
+                        onClickLabel = stringResource(StringsR.string.artwork),
                         onClick = onLoadedArtworkClick
                     )
                 } else {

--- a/feature/track/src/main/java/com/mrsep/musicrecognizer/feature/track/presentation/track/TrackActionsBottomBar.kt
+++ b/feature/track/src/main/java/com/mrsep/musicrecognizer/feature/track/presentation/track/TrackActionsBottomBar.kt
@@ -39,7 +39,11 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.CustomAccessibilityAction
 import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.customActions
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.mrsep.musicrecognizer.core.ui.components.VinylRotating
@@ -170,6 +174,11 @@ private fun LyricsFloatingActionButtonWithTooltip(
         )
         val lyricsButtonExtraElevation by animateDpAsState(if (isLyricsAvailable) 2.dp else 1.dp)
         Box {
+            val lyricsStateDesc = when {
+                isLyricsLoading -> stringResource(StringsR.string.searching_for_lyrics)
+                !isLyricsAvailable -> stringResource(StringsR.string.no_lyrics_available)
+                else -> null
+            }
             FloatingActionButton(
                 onClick = {
                     if (isLyricsAvailable) {
@@ -178,6 +187,9 @@ private fun LyricsFloatingActionButtonWithTooltip(
                     } else {
                         scope.launch { tooltipState.show() }
                     }
+                },
+                modifier = Modifier.semantics {
+                    lyricsStateDesc?.let { stateDescription = it }
                 },
                 containerColor = MaterialTheme.colorScheme.tertiaryContainer
                     .copy(alpha = lyricsButtonAlpha)
@@ -247,14 +259,23 @@ private fun RetryRecognitionButtonWithTooltip(
             }
         },
     ) {
+        val retryActionLabel = stringResource(StringsR.string.button_retry_recognition)
         Box(
             modifier = modifier
                 .size(40.dp)
                 .clip(CircleShape)
+                .semantics {
+                    customActions = listOf(
+                        CustomAccessibilityAction(label = retryActionLabel) {
+                            onRetryRequested()
+                            true
+                        }
+                    )
+                }
                 .combinedClickable(
                     role = Role.Button,
                     onClickLabel = stringResource(StringsR.string.button_retry_recognition_hint),
-                    onLongClickLabel = stringResource(StringsR.string.button_retry_recognition),
+                    onLongClickLabel = retryActionLabel,
                     onClick = {
                         scope.launch { tooltipState.show() }
                     },


### PR DESCRIPTION
Fixes #175

### Summary

This pull request improves accessibility and screen reader support (TalkBack, Jieshuo, etc.) across Audile's Jetpack Compose UI. It addresses several missing semantic roles, hidden state announcements, redundant click targets, and gesture-only actions without altering the visual design, adding dependencies, or modifying non-English strings (per `CONTRIBUTING.md` Weblate policy).

---

### Detailed Changes

#### 1. Recognition Screen & Live Status Feedback
- **`RecognitionButtonWithTitle.kt`**:
  - Removed `Modifier.clearAndSetSemantics { }` from the status headline above the main button which previously hid recognition status changes from screen readers.
  - Added `Modifier.semantics { liveRegion = LiveRegionMode.Polite }` so state changes ("Listening…", "Recognizing…", etc.) are announced automatically.
  - Clarified `onLongClickLabel` to accurately describe the alternative capture mode trigger.

#### 2. Preference Controls & Headings (`core/ui`)
- **`PreferenceSwitchItem.kt`**:
  - Converted the container `Row` from `clickable` to `Modifier.toggleable(value = checked, role = Role.Switch)`, merging the switch state with title/subtitle and eliminating separate, unlinked focus nodes.
- **`PreferenceClickableItem.kt`**:
  - Added `role = Role.Button` and passed `enabled` to `clickable`.
- **`PreferenceGroup.kt`**:
  - Added `Modifier.semantics { heading() }` to group headers to allow quick heading navigation for screen reader users.

#### 3. Track Details & Lyrics Presentation (`feature/track`)
- **`TrackActionsBottomBar.kt`**:
  - Added a `CustomAccessibilityAction` to the retry button so screen reader users can trigger retry recognition directly from the accessibility actions menu without needing a manual long-press gesture.
  - Added `stateDescription` to the lyrics floating action button to announce "Searching for lyrics…" or "No lyrics available" when active or unavailable.
- **`AlbumArtwork.kt`**:
  - Added `role = Role.Button` and `onClickLabel` when full-screen artwork expansion is enabled.
- **`LyricsStyleBottomSheet.kt`**:
  - Added `contentDescription` and `stateDescription` to the font size `Slider` so current size ("Small", "Normal", "Large", "Huge") is spoken instead of raw float values.
  - Converted `BottomBarSwitch` to `Modifier.toggleable` and cleared duplicate `onCheckedChange` on the inner `Switch`.

#### 4. Library & Search Experience (`feature/library`)
- **`LibraryScreenTopBar.kt` & `SearchScopeDropdownMenu.kt`**:
  - Exposed `Role.Checkbox` and `selected` state on `DropdownMenuItem` elements (grid layout toggle, date toggle, search scope fields) so screen readers report checked/unchecked states rather than generic uninformative menu items.
- **`TrackLazyColumn.kt`, `TrackLazyGrid.kt`, `TrackSearchItem.kt`**:
  - Added `Modifier.semantics(mergeDescendants = true)` with `Role.Button` and `selected` state during multi-selection, providing a concise, single-node announcement for track items (artwork, title, artist, date).

#### 5. Backup & CSV Export (`feature/backup`)
- **`BackupDialog.kt`**:
  - Converted `BackupEntryCheckBox` to `Modifier.toggleable(role = Role.Checkbox)` with `onCheckedChange = null` on the child checkbox to prevent double-focus issues.
- **`CsvExportFullScreenDialog.kt`**:
  - Extracted hardcoded `"Reorder"` drag handle description into localized `R.string.reorder` (`values/strings.xml`).

#### 6. Navigation Bar & Rail (`app`)
- **`AppNavigationBar.kt` & `AppNavigationRail.kt`**:
  - Set `contentDescription = null` for navigation icons when a `label` is provided, preventing screen readers from reading destination names twice.

---

### Verification
- Checked that all semantics changes produce zero visual layout regressions.
- Verified balanced hierarchy and clean Kotlin Compose semantics standards.
- Reverted all non-English string edits to adhere to the Weblate translation workflow.